### PR TITLE
Change community support badge color

### DIFF
--- a/support-labels/README-badges.md
+++ b/support-labels/README-badges.md
@@ -15,7 +15,7 @@ maintained in one place.
 
 ## Community
 
-[![support: community](https://img.shields.io/badge/support-community-2da44e)](https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#extensions-githubcommeshery-extensions)
+[![support: community](https://img.shields.io/badge/support-community-00B39F)](https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#extensions-githubcommeshery-extensions)
 
 ```
 [![support: community](https://img.shields.io/badge/support-community-2da44e)](https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#extensions-githubcommeshery-extensions)


### PR DESCRIPTION
Updated the badge color for the community support link.

Use Meshery green color

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Community support badge color for improved visual presentation.
  * The existing governance link remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->