### PR TITLE
Add all org repositories to profile README table with support badges

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -44,6 +44,7 @@ This organization is managed by Meshery core and extension maintainers. Reposito
     <!-- Repositories section -->
 <div>
     <h2>Repositories</h2>
+    <p>Every repository in this organization carries a support level badge&mdash;<a href="https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#extensions-githubcommeshery-extensions"><b>official</b></a> or <a href="https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#extensions-githubcommeshery-extensions"><b>community</b></a>&mdash;so that you know what to expect in terms of maintenance, support, and release cadence. See <a href="https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#extensions-githubcommeshery-extensions">GOVERNANCE.md</a> for the definition of each level, and <a href="https://github.com/meshery-extensions/.github/blob/master/support-labels/manifest.yaml">support-labels/manifest.yaml</a> for the source of truth behind them.</p>
     <table border="0px" align="center">
         <tr>
             <!-- kanvas-site -->
@@ -52,6 +53,7 @@ This organization is managed by Meshery core and extension maintainers. Reposito
                 <img src="https://raw.githubusercontent.com/meshery-extensions/.github/master/profile/assets/img/meshery-extensions-color.svg" style="margin-right:10px;" width="75px" alt="Meshery Logo" align="left" />
                 <p>The documentation, platform web application site, and landing interface for Kanvas—the collaborative visual designer for cloud-native infrastructure.</p>
                 <p align="left">
+                    <a href="https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#extensions-githubcommeshery-extensions"><img src="https://img.shields.io/badge/support-community-00B39F?style=flat-square&logo=meshery&logoColor=white" alt="Level of support for this repo" /></a>
                     <a href="https://github.com/meshery-extensions/kanvas-site/graphs/contributors"><img src="https://img.shields.io/github/contributors/meshery-extensions/kanvas-site.svg" /></a>
                     <a href="https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Ameshery-extensions+repo%3Akanvas-site+label%3A%22help+wanted%22+"><img src="https://img.shields.io/github/issues/meshery-extensions/kanvas-site/help%20wanted.svg?color=informational" /></a>
                 </p>
@@ -64,6 +66,7 @@ This organization is managed by Meshery core and extension maintainers. Reposito
                 <img src="https://raw.githubusercontent.com/meshery-extensions/.github/master/profile/assets/img/meshery-extensions-color.svg" style="margin-right:10px;" width="75px" alt="Meshery Logo" align="left" />
                 <p>The core rendering library and shared framework driving visual topology captures, state comparison engines, and design export workflows across CLI and Helm extensions.</p>
                 <p align="left">
+                    <a href="https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#extensions-githubcommeshery-extensions"><img src="https://img.shields.io/badge/support-community-00B39F?style=flat-square&logo=meshery&logoColor=white" alt="Level of support for this repo" /></a>
                     <a href="https://github.com/meshery-extensions/kanvas-snapshot/graphs/contributors"><img src="https://img.shields.io/github/contributors/meshery-extensions/kanvas-snapshot.svg" /></a>
                     <a href="https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Ameshery-extensions+repo%3Akanvas-snapshot+label%3A%22help+wanted%22+"><img src="https://img.shields.io/github/issues/meshery-extensions/kanvas-snapshot/help%20wanted.svg?color=informational" /></a>
                 </p>
@@ -76,6 +79,7 @@ This organization is managed by Meshery core and extension maintainers. Reposito
                 <img src="https://raw.githubusercontent.com/meshery-extensions/.github/master/profile/assets/img/meshery-extensions-color.svg" style="margin-right:10px;" width="75px" alt="Meshery Logo" align="left" />
                 <p>A native command-line <code>kubectl</code> plugin configured to easily generate exportable architectural design blueprints and snapshots of live Kubernetes clusters.</p>
                 <p align="left">
+                    <a href="https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#extensions-githubcommeshery-extensions"><img src="https://img.shields.io/badge/support-community-00B39F?style=flat-square&logo=meshery&logoColor=white" alt="Level of support for this repo" /></a>
                     <a href="https://github.com/meshery-extensions/kubectl-kanvas-snapshot/graphs/contributors"><img src="https://img.shields.io/github/contributors/meshery-extensions/kubectl-kanvas-snapshot.svg" /></a>
                     <a href="https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Ameshery-extensions+repo%3Akubectl-kanvas-snapshot+label%3A%22help+wanted%22+"><img src="https://img.shields.io/github/issues/meshery-extensions/kubectl-kanvas-snapshot/help%20wanted.svg?color=informational" /></a>
                 </p>
@@ -88,6 +92,7 @@ This organization is managed by Meshery core and extension maintainers. Reposito
                 <img src="https://raw.githubusercontent.com/meshery-extensions/.github/master/profile/assets/img/meshery-extensions-color.svg" style="margin-right:10px;" width="75px" alt="Meshery Logo" align="left" />
                 <p>A Helm plugin extension engineered to generate exportable visual architectural maps and structural snapshots directly from packaged Helm charts.</p>
                 <p align="left">
+                    <a href="https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#extensions-githubcommeshery-extensions"><img src="https://img.shields.io/badge/support-community-00B39F?style=flat-square&logo=meshery&logoColor=white" alt="Level of support for this repo" /></a>
                     <a href="https://github.com/meshery-extensions/helm-kanvas-snapshot/graphs/contributors"><img src="https://img.shields.io/github/contributors/meshery-extensions/helm-kanvas-snapshot.svg" /></a>
                     <a href="https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Ameshery-extensions+repo%3Ahelm-kanvas-snapshot+label%3A%22help+wanted%22+"><img src="https://img.shields.io/github/issues/meshery-extensions/helm-kanvas-snapshot/help%20wanted.svg?color=informational" /></a>
                 </p>
@@ -100,6 +105,7 @@ This organization is managed by Meshery core and extension maintainers. Reposito
                 <img src="https://raw.githubusercontent.com/meshery-extensions/.github/master/profile/assets/img/meshery-extensions-color.svg" style="margin-right:10px;" width="75px" alt="Meshery Logo" align="left" />
                 <p>An extension adapter designed for managing and orchestrating Nighthawk—the distributed layer-seven traffic and performance benchmarking subsystem.</p>
                 <p align="left">
+                    <a href="https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#extensions-githubcommeshery-extensions"><img src="https://img.shields.io/badge/support-official-2f6feb?style=flat-square&logo=meshery&logoColor=white" alt="Level of support for this repo" /></a>
                     <a href="https://github.com/meshery-extensions/meshery-nighthawk/graphs/contributors"><img src="https://img.shields.io/github/contributors/meshery-extensions/meshery-nighthawk.svg" /></a>
                     <a href="https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Ameshery-extensions+repo%3Ameshery-nighthawk+label%3A%22help+wanted%22+"><img src="https://img.shields.io/github/issues/meshery-extensions/meshery-nighthawk/help%20wanted.svg?color=informational" /></a>
                 </p>
@@ -112,6 +118,7 @@ This organization is managed by Meshery core and extension maintainers. Reposito
                 <img src="https://raw.githubusercontent.com/meshery-extensions/.github/master/profile/assets/img/meshery-extensions-color.svg" style="margin-right:10px;" width="75px" alt="Meshery Logo" align="left" />
                 <p>The centralized distribution hub for packaging, versioning, and releasing bundled assets, plugins, and compiled components across the extended Meshery ecosystem.</p>
                 <p align="left">
+                    <a href="https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#extensions-githubcommeshery-extensions"><img src="https://img.shields.io/badge/support-community-00B39F?style=flat-square&logo=meshery&logoColor=white" alt="Level of support for this repo" /></a>
                     <a href="https://github.com/meshery-extensions/meshery-extensions-packages/graphs/contributors"><img src="https://img.shields.io/github/contributors/meshery-extensions/meshery-extensions-packages.svg" /></a>
                     <a href="https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Ameshery-extensions+repo%3Ameshery-extensions-packages+label%3A%22help+wanted%22+"><img src="https://img.shields.io/github/issues/meshery-extensions/meshery-extensions-packages/help%20wanted.svg?color=informational" /></a>
                 </p>
@@ -124,8 +131,286 @@ This organization is managed by Meshery core and extension maintainers. Reposito
                 <img src="https://raw.githubusercontent.com/meshery-extensions/.github/master/profile/assets/img/meshery-extensions-color.svg" style="margin-right:10px;" width="75px" alt="Meshery Logo" align="left" />
                 <p>The central community interactive learning repository hosting courseware, lab setups, and certification trees for Meshery's broad extension ecosystem.</p>
                 <p align="left">
+                    <a href="https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#extensions-githubcommeshery-extensions"><img src="https://img.shields.io/badge/support-community-00B39F?style=flat-square&logo=meshery&logoColor=white" alt="Level of support for this repo" /></a>
                     <a href="https://github.com/meshery-extensions/meshery-academy/graphs/contributors"><img src="https://img.shields.io/github/contributors/meshery-extensions/meshery-academy.svg" /></a>
                     <a href="https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Ameshery-extensions+repo%3Ameshery-academy+label%3A%22help+wanted%22+"><img src="https://img.shields.io/github/issues/meshery-extensions/meshery-academy/help%20wanted.svg?color=informational" /></a>
+                </p>
+            </td>
+        </tr>
+        <tr>
+            <!-- meshery-istio -->
+            <td style="padding: 28px;">
+                <h2 align="left"><a href="https://github.com/meshery-extensions/meshery-istio">meshery-istio</a></h2>
+                <img src="https://raw.githubusercontent.com/meshery-extensions/.github/master/profile/assets/img/meshery-extensions-color.svg" style="margin-right:10px;" width="75px" alt="Meshery Logo" align="left" />
+                <p>The Meshery adapter for Istio, delivering lifecycle management, configuration validation, and performance characterization of the Istio service mesh and its workloads.</p>
+                <p align="left">
+                    <a href="https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#extensions-githubcommeshery-extensions"><img src="https://img.shields.io/badge/support-official-2f6feb?style=flat-square&logo=meshery&logoColor=white" alt="Level of support for this repo" /></a>
+                    <a href="https://github.com/meshery-extensions/meshery-istio/graphs/contributors"><img src="https://img.shields.io/github/contributors/meshery-extensions/meshery-istio.svg" /></a>
+                    <a href="https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Ameshery-extensions+repo%3Ameshery-istio+label%3A%22help+wanted%22+"><img src="https://img.shields.io/github/issues/meshery-extensions/meshery-istio/help%20wanted.svg?color=informational" /></a>
+                </p>
+            </td>
+        </tr>
+        <tr>
+            <!-- meshery-linkerd -->
+            <td style="padding: 28px;">
+                <h2 align="left"><a href="https://github.com/meshery-extensions/meshery-linkerd">meshery-linkerd</a></h2>
+                <img src="https://raw.githubusercontent.com/meshery-extensions/.github/master/profile/assets/img/meshery-extensions-color.svg" style="margin-right:10px;" width="75px" alt="Meshery Logo" align="left" />
+                <p>The Meshery adapter for Linkerd, handling mesh provisioning, sample application deployment, and conformance and performance testing of Linkerd installations.</p>
+                <p align="left">
+                    <a href="https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#extensions-githubcommeshery-extensions"><img src="https://img.shields.io/badge/support-official-2f6feb?style=flat-square&logo=meshery&logoColor=white" alt="Level of support for this repo" /></a>
+                    <a href="https://github.com/meshery-extensions/meshery-linkerd/graphs/contributors"><img src="https://img.shields.io/github/contributors/meshery-extensions/meshery-linkerd.svg" /></a>
+                    <a href="https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Ameshery-extensions+repo%3Ameshery-linkerd+label%3A%22help+wanted%22+"><img src="https://img.shields.io/github/issues/meshery-extensions/meshery-linkerd/help%20wanted.svg?color=informational" /></a>
+                </p>
+            </td>
+        </tr>
+        <tr>
+            <!-- meshery-consul -->
+            <td style="padding: 28px;">
+                <h2 align="left"><a href="https://github.com/meshery-extensions/meshery-consul">meshery-consul</a></h2>
+                <img src="https://raw.githubusercontent.com/meshery-extensions/.github/master/profile/assets/img/meshery-extensions-color.svg" style="margin-right:10px;" width="75px" alt="Meshery Logo" align="left" />
+                <p>The Meshery adapter for Consul, managing the lifecycle and configuration of Consul service mesh deployments and their connected services.</p>
+                <p align="left">
+                    <a href="https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#extensions-githubcommeshery-extensions"><img src="https://img.shields.io/badge/support-official-2f6feb?style=flat-square&logo=meshery&logoColor=white" alt="Level of support for this repo" /></a>
+                    <a href="https://github.com/meshery-extensions/meshery-consul/graphs/contributors"><img src="https://img.shields.io/github/contributors/meshery-extensions/meshery-consul.svg" /></a>
+                    <a href="https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Ameshery-extensions+repo%3Ameshery-consul+label%3A%22help+wanted%22+"><img src="https://img.shields.io/github/issues/meshery-extensions/meshery-consul/help%20wanted.svg?color=informational" /></a>
+                </p>
+            </td>
+        </tr>
+        <tr>
+            <!-- meshery-cilium -->
+            <td style="padding: 28px;">
+                <h2 align="left"><a href="https://github.com/meshery-extensions/meshery-cilium">meshery-cilium</a></h2>
+                <img src="https://raw.githubusercontent.com/meshery-extensions/.github/master/profile/assets/img/meshery-extensions-color.svg" style="margin-right:10px;" width="75px" alt="Meshery Logo" align="left" />
+                <p>The Meshery adapter for Cilium Service Mesh, bringing eBPF-based networking, observability, and security policy under Meshery's unified management model.</p>
+                <p align="left">
+                    <a href="https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#extensions-githubcommeshery-extensions"><img src="https://img.shields.io/badge/support-official-2f6feb?style=flat-square&logo=meshery&logoColor=white" alt="Level of support for this repo" /></a>
+                    <a href="https://github.com/meshery-extensions/meshery-cilium/graphs/contributors"><img src="https://img.shields.io/github/contributors/meshery-extensions/meshery-cilium.svg" /></a>
+                    <a href="https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Ameshery-extensions+repo%3Ameshery-cilium+label%3A%22help+wanted%22+"><img src="https://img.shields.io/github/issues/meshery-extensions/meshery-cilium/help%20wanted.svg?color=informational" /></a>
+                </p>
+            </td>
+        </tr>
+        <tr>
+            <!-- meshery-kuma -->
+            <td style="padding: 28px;">
+                <h2 align="left"><a href="https://github.com/meshery-extensions/meshery-kuma">meshery-kuma</a></h2>
+                <img src="https://raw.githubusercontent.com/meshery-extensions/.github/master/profile/assets/img/meshery-extensions-color.svg" style="margin-right:10px;" width="75px" alt="Meshery Logo" align="left" />
+                <p>The Meshery adapter for Kuma, providing lifecycle management and operational insight for Kuma control planes and their attached data plane proxies.</p>
+                <p align="left">
+                    <a href="https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#extensions-githubcommeshery-extensions"><img src="https://img.shields.io/badge/support-official-2f6feb?style=flat-square&logo=meshery&logoColor=white" alt="Level of support for this repo" /></a>
+                    <a href="https://github.com/meshery-extensions/meshery-kuma/graphs/contributors"><img src="https://img.shields.io/github/contributors/meshery-extensions/meshery-kuma.svg" /></a>
+                    <a href="https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Ameshery-extensions+repo%3Ameshery-kuma+label%3A%22help+wanted%22+"><img src="https://img.shields.io/github/issues/meshery-extensions/meshery-kuma/help%20wanted.svg?color=informational" /></a>
+                </p>
+            </td>
+        </tr>
+        <tr>
+            <!-- meshery-nsm -->
+            <td style="padding: 28px;">
+                <h2 align="left"><a href="https://github.com/meshery-extensions/meshery-nsm">meshery-nsm</a></h2>
+                <img src="https://raw.githubusercontent.com/meshery-extensions/.github/master/profile/assets/img/meshery-extensions-color.svg" style="margin-right:10px;" width="75px" alt="Meshery Logo" align="left" />
+                <p>The Meshery adapter for Network Service Mesh, managing NSM deployments and the dynamic, workload-level network service connections they establish.</p>
+                <p align="left">
+                    <a href="https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#extensions-githubcommeshery-extensions"><img src="https://img.shields.io/badge/support-official-2f6feb?style=flat-square&logo=meshery&logoColor=white" alt="Level of support for this repo" /></a>
+                    <a href="https://github.com/meshery-extensions/meshery-nsm/graphs/contributors"><img src="https://img.shields.io/github/contributors/meshery-extensions/meshery-nsm.svg" /></a>
+                    <a href="https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Ameshery-extensions+repo%3Ameshery-nsm+label%3A%22help+wanted%22+"><img src="https://img.shields.io/github/issues/meshery-extensions/meshery-nsm/help%20wanted.svg?color=informational" /></a>
+                </p>
+            </td>
+        </tr>
+        <tr>
+            <!-- meshery-app-mesh -->
+            <td style="padding: 28px;">
+                <h2 align="left"><a href="https://github.com/meshery-extensions/meshery-app-mesh">meshery-app-mesh</a></h2>
+                <img src="https://raw.githubusercontent.com/meshery-extensions/.github/master/profile/assets/img/meshery-extensions-color.svg" style="margin-right:10px;" width="75px" alt="Meshery Logo" align="left" />
+                <p>The Meshery adapter for AWS App Mesh, managing App Mesh lifecycle operations and configuration across Amazon's managed service mesh offering.</p>
+                <p align="left">
+                    <a href="https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#extensions-githubcommeshery-extensions"><img src="https://img.shields.io/badge/support-official-2f6feb?style=flat-square&logo=meshery&logoColor=white" alt="Level of support for this repo" /></a>
+                    <a href="https://github.com/meshery-extensions/meshery-app-mesh/graphs/contributors"><img src="https://img.shields.io/github/contributors/meshery-extensions/meshery-app-mesh.svg" /></a>
+                    <a href="https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Ameshery-extensions+repo%3Ameshery-app-mesh+label%3A%22help+wanted%22+"><img src="https://img.shields.io/github/issues/meshery-extensions/meshery-app-mesh/help%20wanted.svg?color=informational" /></a>
+                </p>
+            </td>
+        </tr>
+        <tr>
+            <!-- meshery-traefik-mesh -->
+            <td style="padding: 28px;">
+                <h2 align="left"><a href="https://github.com/meshery-extensions/meshery-traefik-mesh">meshery-traefik-mesh</a></h2>
+                <img src="https://raw.githubusercontent.com/meshery-extensions/.github/master/profile/assets/img/meshery-extensions-color.svg" style="margin-right:10px;" width="75px" alt="Meshery Logo" align="left" />
+                <p>The Meshery adapter for Traefik Mesh, covering lifecycle management, configuration, and performance characterization of Traefik's lightweight service mesh.</p>
+                <p align="left">
+                    <a href="https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#extensions-githubcommeshery-extensions"><img src="https://img.shields.io/badge/support-official-2f6feb?style=flat-square&logo=meshery&logoColor=white" alt="Level of support for this repo" /></a>
+                    <a href="https://github.com/meshery-extensions/meshery-traefik-mesh/graphs/contributors"><img src="https://img.shields.io/github/contributors/meshery-extensions/meshery-traefik-mesh.svg" /></a>
+                    <a href="https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Ameshery-extensions+repo%3Ameshery-traefik-mesh+label%3A%22help+wanted%22+"><img src="https://img.shields.io/github/issues/meshery-extensions/meshery-traefik-mesh/help%20wanted.svg?color=informational" /></a>
+                </p>
+            </td>
+        </tr>
+        <tr>
+            <!-- meshery-nginx-sm -->
+            <td style="padding: 28px;">
+                <h2 align="left"><a href="https://github.com/meshery-extensions/meshery-nginx-sm">meshery-nginx-sm</a></h2>
+                <img src="https://raw.githubusercontent.com/meshery-extensions/.github/master/profile/assets/img/meshery-extensions-color.svg" style="margin-right:10px;" width="75px" alt="Meshery Logo" align="left" />
+                <p>The Meshery adapter for NGINX Service Mesh, managing the deployment, configuration, and operational lifecycle of NGINX-based mesh installations.</p>
+                <p align="left">
+                    <a href="https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#extensions-githubcommeshery-extensions"><img src="https://img.shields.io/badge/support-official-2f6feb?style=flat-square&logo=meshery&logoColor=white" alt="Level of support for this repo" /></a>
+                    <a href="https://github.com/meshery-extensions/meshery-nginx-sm/graphs/contributors"><img src="https://img.shields.io/github/contributors/meshery-extensions/meshery-nginx-sm.svg" /></a>
+                    <a href="https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Ameshery-extensions+repo%3Ameshery-nginx-sm+label%3A%22help+wanted%22+"><img src="https://img.shields.io/github/issues/meshery-extensions/meshery-nginx-sm/help%20wanted.svg?color=informational" /></a>
+                </p>
+            </td>
+        </tr>
+        <tr>
+            <!-- meshery-adapter-template -->
+            <td style="padding: 28px;">
+                <h2 align="left"><a href="https://github.com/meshery-extensions/meshery-adapter-template">meshery-adapter-template</a></h2>
+                <img src="https://raw.githubusercontent.com/meshery-extensions/.github/master/profile/assets/img/meshery-extensions-color.svg" style="margin-right:10px;" width="75px" alt="Meshery Logo" align="left" />
+                <p>The canonical template repository and scaffolding used to bootstrap new Meshery adapters, complete with the shared adapter library, gRPC contracts, and CI conventions.</p>
+                <p align="left">
+                    <a href="https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#extensions-githubcommeshery-extensions"><img src="https://img.shields.io/badge/support-official-2f6feb?style=flat-square&logo=meshery&logoColor=white" alt="Level of support for this repo" /></a>
+                    <a href="https://github.com/meshery-extensions/meshery-adapter-template/graphs/contributors"><img src="https://img.shields.io/github/contributors/meshery-extensions/meshery-adapter-template.svg" /></a>
+                    <a href="https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Ameshery-extensions+repo%3Ameshery-adapter-template+label%3A%22help+wanted%22+"><img src="https://img.shields.io/github/issues/meshery-extensions/meshery-adapter-template/help%20wanted.svg?color=informational" /></a>
+                </p>
+            </td>
+        </tr>
+        <tr>
+            <!-- kubectl-meshsync-snapshot -->
+            <td style="padding: 28px;">
+                <h2 align="left"><a href="https://github.com/meshery-extensions/kubectl-meshsync-snapshot">kubectl-meshsync-snapshot</a></h2>
+                <img src="https://raw.githubusercontent.com/meshery-extensions/.github/master/profile/assets/img/meshery-extensions-color.svg" style="margin-right:10px;" width="75px" alt="Meshery Logo" align="left" />
+                <p>A <code>kubectl</code> plugin that captures a MeshSync snapshot of the current state of your Kubernetes cluster and uploads it to Meshery as a design.</p>
+                <p align="left">
+                    <a href="https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#extensions-githubcommeshery-extensions"><img src="https://img.shields.io/badge/support-official-2f6feb?style=flat-square&logo=meshery&logoColor=white" alt="Level of support for this repo" /></a>
+                    <a href="https://github.com/meshery-extensions/kubectl-meshsync-snapshot/graphs/contributors"><img src="https://img.shields.io/github/contributors/meshery-extensions/kubectl-meshsync-snapshot.svg" /></a>
+                    <a href="https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Ameshery-extensions+repo%3Akubectl-meshsync-snapshot+label%3A%22help+wanted%22+"><img src="https://img.shields.io/github/issues/meshery-extensions/kubectl-meshsync-snapshot/help%20wanted.svg?color=informational" /></a>
+                </p>
+            </td>
+        </tr>
+        <tr>
+            <!-- digitalocean-academy -->
+            <td style="padding: 28px;">
+                <h2 align="left"><a href="https://github.com/meshery-extensions/digitalocean-academy">digitalocean-academy</a></h2>
+                <img src="https://raw.githubusercontent.com/meshery-extensions/.github/master/profile/assets/img/meshery-extensions-color.svg" style="margin-right:10px;" width="75px" alt="Meshery Logo" align="left" />
+                <p>The Meshery Academy for DigitalOcean—hands-on courseware and labs teaching cloud native operations on DigitalOcean Kubernetes.</p>
+                <p align="left">
+                    <a href="https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#extensions-githubcommeshery-extensions"><img src="https://img.shields.io/badge/support-community-00B39F?style=flat-square&logo=meshery&logoColor=white" alt="Level of support for this repo" /></a>
+                    <a href="https://github.com/meshery-extensions/digitalocean-academy/graphs/contributors"><img src="https://img.shields.io/github/contributors/meshery-extensions/digitalocean-academy.svg" /></a>
+                    <a href="https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Ameshery-extensions+repo%3Adigitalocean-academy+label%3A%22help+wanted%22+"><img src="https://img.shields.io/github/issues/meshery-extensions/digitalocean-academy/help%20wanted.svg?color=informational" /></a>
+                </p>
+            </td>
+        </tr>
+        <tr>
+            <!-- tcslabs-academy -->
+            <td style="padding: 28px;">
+                <h2 align="left"><a href="https://github.com/meshery-extensions/tcslabs-academy">tcslabs-academy</a></h2>
+                <img src="https://raw.githubusercontent.com/meshery-extensions/.github/master/profile/assets/img/meshery-extensions-color.svg" style="margin-right:10px;" width="75px" alt="Meshery Logo" align="left" />
+                <p>The Meshery Academy for TCS Labs—a partner-tailored learning path of courses, labs, and challenges built on the Academy platform.</p>
+                <p align="left">
+                    <a href="https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#extensions-githubcommeshery-extensions"><img src="https://img.shields.io/badge/support-community-00B39F?style=flat-square&logo=meshery&logoColor=white" alt="Level of support for this repo" /></a>
+                    <a href="https://github.com/meshery-extensions/tcslabs-academy/graphs/contributors"><img src="https://img.shields.io/github/contributors/meshery-extensions/tcslabs-academy.svg" /></a>
+                    <a href="https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Ameshery-extensions+repo%3Atcslabs-academy+label%3A%22help+wanted%22+"><img src="https://img.shields.io/github/issues/meshery-extensions/tcslabs-academy/help%20wanted.svg?color=informational" /></a>
+                </p>
+            </td>
+        </tr>
+        <tr>
+            <!-- shape-builder -->
+            <td style="padding: 28px;">
+                <h2 align="left"><a href="https://github.com/meshery-extensions/shape-builder">shape-builder</a></h2>
+                <img src="https://raw.githubusercontent.com/meshery-extensions/.github/master/profile/assets/img/meshery-extensions-color.svg" style="margin-right:10px;" width="75px" alt="Meshery Logo" align="left" />
+                <p>A Meshery extension for authoring custom polygon shapes used to visually represent Meshery components on the Kanvas canvas.</p>
+                <p align="left">
+                    <a href="https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#extensions-githubcommeshery-extensions"><img src="https://img.shields.io/badge/support-community-00B39F?style=flat-square&logo=meshery&logoColor=white" alt="Level of support for this repo" /></a>
+                    <a href="https://github.com/meshery-extensions/shape-builder/graphs/contributors"><img src="https://img.shields.io/github/contributors/meshery-extensions/shape-builder.svg" /></a>
+                    <a href="https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Ameshery-extensions+repo%3Ashape-builder+label%3A%22help+wanted%22+"><img src="https://img.shields.io/github/issues/meshery-extensions/shape-builder/help%20wanted.svg?color=informational" /></a>
+                </p>
+            </td>
+        </tr>
+        <tr>
+            <!-- meshery-mcp-server -->
+            <td style="padding: 28px;">
+                <h2 align="left"><a href="https://github.com/meshery-extensions/meshery-mcp-server">meshery-mcp-server</a></h2>
+                <img src="https://raw.githubusercontent.com/meshery-extensions/.github/master/profile/assets/img/meshery-extensions-color.svg" style="margin-right:10px;" width="75px" alt="Meshery Logo" align="left" />
+                <p>The Meshery MCP Server extension—a Model Context Protocol server that lets AI assistants create, inspect, and accelerate the design of Meshery designs.</p>
+                <p align="left">
+                    <a href="https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#extensions-githubcommeshery-extensions"><img src="https://img.shields.io/badge/support-community-00B39F?style=flat-square&logo=meshery&logoColor=white" alt="Level of support for this repo" /></a>
+                    <a href="https://github.com/meshery-extensions/meshery-mcp-server/graphs/contributors"><img src="https://img.shields.io/github/contributors/meshery-extensions/meshery-mcp-server.svg" /></a>
+                    <a href="https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Ameshery-extensions+repo%3Ameshery-mcp-server+label%3A%22help+wanted%22+"><img src="https://img.shields.io/github/issues/meshery-extensions/meshery-mcp-server/help%20wanted.svg?color=informational" /></a>
+                </p>
+            </td>
+        </tr>
+        <tr>
+            <!-- integrations-workflow -->
+            <td style="padding: 28px;">
+                <h2 align="left"><a href="https://github.com/meshery-extensions/integrations-workflow">integrations-workflow</a></h2>
+                <img src="https://raw.githubusercontent.com/meshery-extensions/.github/master/profile/assets/img/meshery-extensions-color.svg" style="margin-right:10px;" width="75px" alt="Meshery Logo" align="left" />
+                <p>The Meshery Integrator and provider notifier workflows that automate integration onboarding, registry updates, and downstream notifications across the ecosystem.</p>
+                <p align="left">
+                    <a href="https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#extensions-githubcommeshery-extensions"><img src="https://img.shields.io/badge/support-official-2f6feb?style=flat-square&logo=meshery&logoColor=white" alt="Level of support for this repo" /></a>
+                    <a href="https://github.com/meshery-extensions/integrations-workflow/graphs/contributors"><img src="https://img.shields.io/github/contributors/meshery-extensions/integrations-workflow.svg" /></a>
+                    <a href="https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Ameshery-extensions+repo%3Aintegrations-workflow+label%3A%22help+wanted%22+"><img src="https://img.shields.io/github/issues/meshery-extensions/integrations-workflow/help%20wanted.svg?color=informational" /></a>
+                </p>
+            </td>
+        </tr>
+        <tr>
+            <!-- .github -->
+            <td style="padding: 28px;">
+                <h2 align="left"><a href="https://github.com/meshery-extensions/.github">.github</a></h2>
+                <img src="https://raw.githubusercontent.com/meshery-extensions/.github/master/profile/assets/img/meshery-extensions-color.svg" style="margin-right:10px;" width="75px" alt="Meshery Logo" align="left" />
+                <p>Organization-level community health files, this profile README, and the support-label manifest and automation that keep every repository's support level in sync.</p>
+                <p align="left">
+                    <a href="https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#extensions-githubcommeshery-extensions"><img src="https://img.shields.io/badge/support-official-2f6feb?style=flat-square&logo=meshery&logoColor=white" alt="Level of support for this repo" /></a>
+                    <a href="https://github.com/meshery-extensions/.github/graphs/contributors"><img src="https://img.shields.io/github/contributors/meshery-extensions/.github.svg" /></a>
+                    <a href="https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Ameshery-extensions+repo%3A.github+label%3A%22help+wanted%22+"><img src="https://img.shields.io/github/issues/meshery-extensions/.github/help%20wanted.svg?color=informational" /></a>
+                </p>
+            </td>
+        </tr>
+    </table>
+    <h3>Archived repositories</h3>
+    <p>These adapters are retained for historical reference. They are no longer maintained and are not compatible with current Meshery releases.</p>
+    <table border="0px" align="center">
+        <tr>
+            <!-- meshery-octarine -->
+            <td style="padding: 28px;">
+                <h2 align="left"><a href="https://github.com/meshery-extensions/meshery-octarine">meshery-octarine</a></h2>
+                <img src="https://raw.githubusercontent.com/meshery-extensions/.github/master/profile/assets/img/meshery-extensions-color.svg" style="margin-right:10px;" width="75px" alt="Meshery Logo" align="left" />
+                <p>The Meshery adapter for Octarine. Archived; the upstream project is no longer maintained.</p>
+                <p align="left">
+                    <a href="https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#extensions-githubcommeshery-extensions"><img src="https://img.shields.io/badge/support-official-2f6feb?style=flat-square&logo=meshery&logoColor=white" alt="Level of support for this repo" /></a>
+                    <img src="https://img.shields.io/badge/status-archived-8b8b8b?style=flat-square" alt="This repository is archived" />
+                    <a href="https://github.com/meshery-extensions/meshery-octarine/graphs/contributors"><img src="https://img.shields.io/github/contributors/meshery-extensions/meshery-octarine.svg" /></a>
+                </p>
+            </td>
+        </tr>
+        <tr>
+            <!-- meshery-cpx -->
+            <td style="padding: 28px;">
+                <h2 align="left"><a href="https://github.com/meshery-extensions/meshery-cpx">meshery-cpx</a></h2>
+                <img src="https://raw.githubusercontent.com/meshery-extensions/.github/master/profile/assets/img/meshery-extensions-color.svg" style="margin-right:10px;" width="75px" alt="Meshery Logo" align="left" />
+                <p>The Meshery adapter for Citrix Service Mesh (CPX). Archived; the upstream project is no longer maintained.</p>
+                <p align="left">
+                    <a href="https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#extensions-githubcommeshery-extensions"><img src="https://img.shields.io/badge/support-official-2f6feb?style=flat-square&logo=meshery&logoColor=white" alt="Level of support for this repo" /></a>
+                    <img src="https://img.shields.io/badge/status-archived-8b8b8b?style=flat-square" alt="This repository is archived" />
+                    <a href="https://github.com/meshery-extensions/meshery-cpx/graphs/contributors"><img src="https://img.shields.io/github/contributors/meshery-extensions/meshery-cpx.svg" /></a>
+                </p>
+            </td>
+        </tr>
+        <tr>
+            <!-- meshery-tanzu-sm -->
+            <td style="padding: 28px;">
+                <h2 align="left"><a href="https://github.com/meshery-extensions/meshery-tanzu-sm">meshery-tanzu-sm</a></h2>
+                <img src="https://raw.githubusercontent.com/meshery-extensions/.github/master/profile/assets/img/meshery-extensions-color.svg" style="margin-right:10px;" width="75px" alt="Meshery Logo" align="left" />
+                <p>The Meshery adapter for VMware Tanzu Service Mesh. Archived; the upstream project is no longer maintained.</p>
+                <p align="left">
+                    <a href="https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#extensions-githubcommeshery-extensions"><img src="https://img.shields.io/badge/support-official-2f6feb?style=flat-square&logo=meshery&logoColor=white" alt="Level of support for this repo" /></a>
+                    <img src="https://img.shields.io/badge/status-archived-8b8b8b?style=flat-square" alt="This repository is archived" />
+                    <a href="https://github.com/meshery-extensions/meshery-tanzu-sm/graphs/contributors"><img src="https://img.shields.io/github/contributors/meshery-extensions/meshery-tanzu-sm.svg" /></a>
+                </p>
+            </td>
+        </tr>
+        <tr>
+            <!-- meshery-osm -->
+            <td style="padding: 28px;">
+                <h2 align="left"><a href="https://github.com/meshery-extensions/meshery-osm">meshery-osm</a></h2>
+                <img src="https://raw.githubusercontent.com/meshery-extensions/.github/master/profile/assets/img/meshery-extensions-color.svg" style="margin-right:10px;" width="75px" alt="Meshery Logo" align="left" />
+                <p>The Meshery adapter for Open Service Mesh. Archived; the upstream project is no longer maintained.</p>
+                <p align="left">
+                    <a href="https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#extensions-githubcommeshery-extensions"><img src="https://img.shields.io/badge/support-official-2f6feb?style=flat-square&logo=meshery&logoColor=white" alt="Level of support for this repo" /></a>
+                    <img src="https://img.shields.io/badge/status-archived-8b8b8b?style=flat-square" alt="This repository is archived" />
+                    <a href="https://github.com/meshery-extensions/meshery-osm/graphs/contributors"><img src="https://img.shields.io/github/contributors/meshery-extensions/meshery-osm.svg" /></a>
                 </p>
             </td>
         </tr>


### PR DESCRIPTION
## What

The Repositories table in `profile/README.md` listed 7 of the organization's 28 repositories. This adds the remaining 21, and adds the support level badge to **every** entry in the table.

## Support badges

Badge markup is the canonical HTML snippet from [`support-labels/README-badges.md`](https://github.com/meshery-extensions/.github/blob/master/support-labels/README-badges.md). Each repo's level (`official` / `community`) comes from [`support-labels/manifest.yaml`](https://github.com/meshery-extensions/.github/blob/master/support-labels/manifest.yaml) — the source of truth that `apply-support-labels.yml` pushes out as custom properties and topics — so the README now agrees with the labels applied to the repos themselves. Verified programmatically: all 28 manifest entries appear in the table, with zero label mismatches and nothing listed that isn't in the manifest.

This is step 5 of `support-labels/IMPLEMENTATION.md` ("Add badges") as it applies to this repo's profile README.

## Repositories added

**Adapters** (official): `meshery-istio`, `meshery-linkerd`, `meshery-consul`, `meshery-cilium`, `meshery-kuma`, `meshery-nsm`, `meshery-app-mesh`, `meshery-traefik-mesh`, `meshery-nginx-sm`, `meshery-adapter-template`

**CLI** (official): `kubectl-meshsync-snapshot`

**Academies** (community): `digitalocean-academy`, `tcslabs-academy`

**Other extensions and org tooling**: `shape-builder` (community), `meshery-mcp-server` (community), `integrations-workflow` (official), `.github` (official)

**Archived** (official): `meshery-octarine`, `meshery-cpx`, `meshery-tanzu-sm`, `meshery-osm`

## Notes on presentation

- The four archived adapters are in a separate **Archived repositories** table rather than mixed into the main one, so the listing is complete without presenting unmaintained adapters as current. They carry their support badge plus an archived shield, and drop the help-wanted link since it filters on `archived:false` anyway.
- A short lead-in paragraph above the table explains the badge and links to the GOVERNANCE.md definitions and the manifest.
- Existing entries are untouched apart from the added badge line — the diff is purely additive (285 insertions, 0 deletions), and each new entry follows the established row structure, logo, and badge conventions.
- Descriptions for new entries are written to match the tone of the existing ones, based on each repo's GitHub description and role in the ecosystem. Happy to adjust any that don't read the way you'd like.

---
_Generated by [Claude Code](https://claude.ai/code/session_016RuAouJAr5WXP6SgGq1mEo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added support-level badges and links to governance definitions and support-label resources.
  * Classified existing repositories as community- or officially supported.
  * Added documentation for additional adapters, CLI extensions, academies, workflows, and organizational support repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->